### PR TITLE
Update make and run scripts

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -1,9 +1,12 @@
 pushd src
 
-$files = $(ls algorithms/*.cpp -name | foreach{echo algorithms\$_})
+$files = $(Get-ChildItem algorithms/*.cpp -name | foreach {
+    echo "algorithms/$_"
+})
 
 g++ -o main.exe `
-    -std=c++11 `
+    -std=c++14 `
     -I algorithms $files `
     main.cpp TSP.cpp graph.cpp
+
 popd

--- a/make.sh
+++ b/make.sh
@@ -1,6 +1,6 @@
 cd src && \
     g++ -o main.exe \
-    -std=c++11 \
+    -std=c++14 \
     -I algorithms algorithms/*.cpp \
     main.cpp TSP.cpp graph.cpp
     

--- a/run.ps1
+++ b/run.ps1
@@ -2,4 +2,4 @@ echo "Compiling..."
 ./make.ps1
 
 echo "Executing..."
-gc src/in.txt | src/main.exe 2>&1 | Tee-Object -FilePath src/out.txt
+gc src/in.txt | src/main.exe 2>&1 @Args | Tee-Object -FilePath src/out.txt

--- a/run.sh
+++ b/run.sh
@@ -2,4 +2,4 @@ echo "Compiling..."
 ./make.sh
 
 echo "Executing..."
-src/main.exe < src/in.txt 2>&1 | tee src/out.txt
+src/main.exe < src/in.txt 2>&1 "$@" | tee src/out.txt


### PR DESCRIPTION
Also change make.ps1 to avoid using "ls" because it is not portable.
To make the script consistent between SOs it is necessary
to use the full form of each command.